### PR TITLE
merge

### DIFF
--- a/qtwinmigrate/src/qwinwidget.cpp
+++ b/qtwinmigrate/src/qwinwidget.cpp
@@ -123,6 +123,9 @@ void QWinWidget::init()
     Q_ASSERT(hParent);
 
     if (hParent) {
+#if QT_VERSION >= 0x050000
+        setProperty("_q_embedded_native_parent_handle", WId(hParent));
+#endif
 	// make the widget window style be WS_CHILD so SetParent will work
 	QT_WA({
         SetWindowLong((HWND)winId(), GWL_STYLE, WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS);
@@ -131,7 +134,6 @@ void QWinWidget::init()
 	})
 #if QT_VERSION >= 0x050000
         QWindow *window = windowHandle();
-        window->setProperty("_q_embedded_native_parent_handle", (WId)hParent);
         HWND h = static_cast<HWND>(QGuiApplication::platformNativeInterface()->
                                 nativeResourceForWindow("handle", window));
         SetParent(h, hParent);


### PR DESCRIPTION
Set the property "_q_embedded_native_parent_handle" on the
widget before calling winId() so that it takes effect
during native window creation.

The bug was unveiled by
qtbase/3035400f36731c400adb9204b94e9afe346a71b7.

Task-number: QTSOLBUG-196
Change-Id: I5dac836b2845de9833da46bfb72d07aafdf4896a
Reviewed-by: Andy Shaw <andy.shaw@qt.io>